### PR TITLE
[GCL] Fix for newer HMM versions constantly bring up update prompt

### DIFF
--- a/src/LostCodeLoader/LostCodeLoader.rc
+++ b/src/LostCodeLoader/LostCodeLoader.rc
@@ -69,12 +69,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "NeverFinishAnything"
             VALUE "FileDescription", "Code loader for Sonic Generations"
-            VALUE "FileVersion", "2.4.4"
+            VALUE "FileVersion", "2.4.4.0"
             VALUE "InternalName", "GenerationsCodeLoader.dll"
             VALUE "LegalCopyright", "Copyright (C) 2020"
             VALUE "OriginalFilename", "GenerationsCodeLoader.dll"
             VALUE "ProductName", "Generations Code Loader"
-            VALUE "ProductVersion", "2.4.4"
+            VALUE "ProductVersion", "2.4.4.0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
once recompiled and put onto the HMM repo, this will fix the issue where newer HMM versions will constantly prompt the user to update, despite already being up to date

![2021-08-18_13-42-21_HedgeModManager](https://user-images.githubusercontent.com/15317421/129969427-bdaada5d-6617-4d7d-82e5-a6f02bd83e0e.png)
