### PR TITLE
Force dll to load from bottom to top

### DIFF
--- a/src/LostCodeLoader/dllmain.cpp
+++ b/src/LostCodeLoader/dllmain.cpp
@@ -156,7 +156,7 @@ void InitMods()
 
 	vector<string*> strings;
 	int count = modsdb.GetInteger("Main", "ActiveModCount", 0);
-	for (int i = count - 1; i > 0; i--)
+	for (int i = count - 1; i >= 0; i--)
 	{
 		string name = modsdb.GetString("Main", "ActiveMod" + to_string(i), "");
 		string path = modsdb.GetString("Mods", name, "");

--- a/src/LostCodeLoader/dllmain.cpp
+++ b/src/LostCodeLoader/dllmain.cpp
@@ -156,7 +156,7 @@ void InitMods()
 
 	vector<string*> strings;
 	int count = modsdb.GetInteger("Main", "ActiveModCount", 0);
-	for (int i = 0; i < count; i++)
+	for (int i = count - 1; i > 0; i--)
 	{
 		string name = modsdb.GetString("Main", "ActiveMod" + to_string(i), "");
 		string path = modsdb.GetString("Mods", name, "");


### PR DESCRIPTION
Fix dll load order so mods higher in the list takes priority over lower ones

List:
mod A -> write address 0x123456 to 0x69
mod B -> write address 0x123456 to 0x00

Result: 0x00 is written first, then 0x69 overwrites it, so 0x69 is used