### PR TITLE
Force dll to load from bottom to top (for SLW)

### DIFF
--- a/src/LostCodeLoader/dllmain.cpp
+++ b/src/LostCodeLoader/dllmain.cpp
@@ -162,7 +162,7 @@ void InitMods()
 
 	vector<string*> strings;
 	int count = modsdb.GetInteger("Main", "ActiveModCount", 0);
-	for (int i = 0; i < count; i++)
+	for (int i = count - 1; i >= 0; i--)
 	{
 		string name = modsdb.GetString("Main", "ActiveMod" + to_string(i), "");
 		string path = modsdb.GetString("Mods", name, "");


### PR DESCRIPTION
Apply the same change from Generations branch